### PR TITLE
Add RSS feed for the blog

### DIFF
--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -57,6 +57,6 @@ export default async function BlogPage() {
 export async function generateMetadata() {
   return {
     title: 'Blog | zkEVM',
-    description: 'Latest updates and insights about zkEVM technology, community updates, and technical developments.',
+    description: 'Latest updates and insights about L1-zkEVM developments.',
   };
 }

--- a/src/app/blog/page.tsx
+++ b/src/app/blog/page.tsx
@@ -12,9 +12,21 @@ export default async function BlogPage() {
           <div className="text-center mb-12">
             <h1 className="text-4xl font-bold mb-4">Latest Updates & Insights</h1>
             <p className="text-xl text-muted-foreground max-w-2xl mx-auto">
-              Stay up to date with the latest developments in zkEVM technology, 
+              Stay up to date with the latest developments in zkEVM technology,
               community updates, and technical insights from our team.
             </p>
+            <a
+              href="/feed.xml"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1.5 mt-4 text-sm text-muted-foreground hover:text-foreground transition-colors"
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="currentColor">
+                <circle cx="6.18" cy="17.82" r="2.18"/>
+                <path d="M4 4.44v2.83c7.03 0 12.73 5.7 12.73 12.73h2.83c0-8.59-6.97-15.56-15.56-15.56zm0 5.66v2.83c3.9 0 7.07 3.17 7.07 7.07h2.83c0-5.47-4.43-9.9-9.9-9.9z"/>
+              </svg>
+              RSS Feed
+            </a>
           </div>
 
 

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -23,7 +23,7 @@ export async function GET() {
   <channel>
     <title>zkEVM Blog</title>
     <link>${SITE_URL}/blog</link>
-    <description>Latest updates and insights about zkEVM technology from the Ethereum Foundation.</description>
+    <description>Latest updates and insights about L1-zkEVM developments from the EF's zkEVM team.</description>
     <language>en</language>
     <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
 ${items}

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,47 @@
+import { getAllBlogPosts } from '@/lib/blog';
+
+const SITE_URL = 'https://zkevm.ethereum.org';
+
+export async function GET() {
+  const posts = await getAllBlogPosts();
+
+  const items = posts
+    .map(
+      (post) => `    <item>
+      <title>${escapeXml(post.title)}</title>
+      <link>${SITE_URL}/blog/${post.slug}</link>
+      <guid isPermaLink="true">${SITE_URL}/blog/${post.slug}</guid>
+      <description>${escapeXml(post.excerpt)}</description>
+      <author>${escapeXml(post.author)}</author>
+      <pubDate>${new Date(post.date).toUTCString()}</pubDate>
+    </item>`
+    )
+    .join('\n');
+
+  const feed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>zkEVM Blog</title>
+    <link>${SITE_URL}/blog</link>
+    <description>Latest updates and insights about zkEVM technology from the Ethereum Foundation.</description>
+    <language>en</language>
+    <atom:link href="${SITE_URL}/feed.xml" rel="self" type="application/rss+xml"/>
+${items}
+  </channel>
+</rss>`;
+
+  return new Response(feed, {
+    headers: {
+      'Content-Type': 'application/rss+xml; charset=utf-8',
+    },
+  });
+}
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,7 @@ export default function RootLayout({
           href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@300;400;500;600;700&family=Inter:wght@300;400;500;600;700&display=swap"
           rel="stylesheet"
         />
+        <link rel="alternate" type="application/rss+xml" title="zkEVM Blog" href="/feed.xml" />
       </head>
       <body>
         <QueryClientWrapper>


### PR DESCRIPTION
 ## Summary                      
  - Add RSS 2.0 feed at `/feed.xml` generated from blog posts                                                                                                                         
  - Add `<link rel="alternate">` in `<head>` for RSS autodiscovery                                                                                                                    
  - Add subtle RSS subscribe link on the blog listing page
  - Shorten blog meta description

  ## Notes
  - No new dependencies — feed XML is generated directly in a Next.js route handler
  - Uses existing `getAllBlogPosts()` to stay in sync with blog content
  
  _supported by claude_