### PR TITLE
Add Zilkworm to Ethereum Clients

### DIFF
--- a/src/data/zkevm-tracker.ts
+++ b/src/data/zkevm-tracker.ts
@@ -137,6 +137,14 @@ export const clientData: ClientInfo[] = [
     links: { github: 'https://github.com/lambdaclass/ethrex' },
     specCompliance: 'compliant',
   },
+  {
+    name: 'Zilkworm',
+    type: 'execution',
+    description: 'C++ ZKEVM core by Erigon, targeting zkVM provers with native RISC-V support.',
+    language: 'C++',
+    links: { github: 'https://github.com/erigontech/zilkworm', website: 'https://zilkworm.erigon.tech' },
+    specCompliance: 'in-progress',
+  },
   // Consensus Layer
   {
     name: 'Lighthouse',


### PR DESCRIPTION
## Summary
Adds Zilkworm (C++ ZKEVM core by Erigon) to the Execution Layer clients list on the Track page.

- Language: C++
- GitHub: https://github.com/erigontech/zilkworm
- Website: https://zilkworm.erigon.tech
- Status: In Progress

Closes #27