### PR TITLE
fix: extract latest run from test monitor data, not oldest

### DIFF
--- a/scripts/transform-test-data.js
+++ b/scripts/transform-test-data.js
@@ -25,8 +25,12 @@ function parseFile(filePath) {
   if (!content || content === '404: Not Found') return null;
   try {
     const data = JSON.parse(content);
-    const run = (data.runs || [])[0];
-    if (!run) return null;
+    const runs = data.runs || [];
+    if (!runs.length) return null;
+    // runs are stored oldest-first; pick the most recent by date
+    const run = runs.reduce((latest, r) =>
+      new Date(r.date) > new Date(latest.date) ? r : latest
+    );
     const passed = Array.isArray(run.passed) ? run.passed.length : 0;
     const failed = Array.isArray(run.failed) ? run.failed.length : 0;
     const total = run.total || (passed + failed);

--- a/src/data/test-monitor-summary.json
+++ b/src/data/test-monitor-summary.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-22T07:10:51.134Z",
+  "lastUpdated": "2026-05-22T15:12:29.272Z",
   "zkvms": {
     "airbender": {
       "isa": "RV32IM",
@@ -93,8 +93,8 @@
     },
     "sp1": {
       "isa": "RV64IM",
-      "commit": "213fc1ab",
-      "lastRun": "2026-03-19T16:24:45Z",
+      "commit": "10995181",
+      "lastRun": "2026-04-15T20:52:07Z",
       "isRV64": true,
       "full": {
         "passed": 62,
@@ -111,8 +111,8 @@
     },
     "zisk": {
       "isa": "RV64IMFDAC",
-      "commit": "aacf0a73",
-      "lastRun": "2026-03-20T14:49:25Z",
+      "commit": "790f9e28",
+      "lastRun": "2026-05-18T14:50:20Z",
       "isRV64": true,
       "full": {
         "passed": 236,
@@ -121,10 +121,10 @@
         "passRate": "98.7"
       },
       "standard": {
-        "passed": 63,
+        "passed": 71,
         "failed": 1,
         "total": 72,
-        "passRate": "87.5"
+        "passRate": "98.6"
       }
     }
   }


### PR DESCRIPTION
## Problem

`scripts/transform-test-data.js` read `data.runs[0]` from each test monitor file. The monitor stores runs **oldest-first**, so the website kept surfacing each zkVM's *first* recorded run rather than its latest.

The nightly sync workflow ran fine and committed daily — but only because the `lastUpdated` timestamp always changes. That masked the fact that the actual test data was frozen (e.g. zisk stuck at its 2026-03-20 run despite newer runs on 2026-04-14 and 2026-05-18).

## Fix

`parseFile` now reduces over all runs and picks the most recent by date.

Regenerated `test-monitor-summary.json` reflects the corrected extraction:
- **sp1** → `2026-03-19` → `2026-04-15` (commit `213fc1ab` → `10995181`)
- **zisk** → `2026-03-20` → `2026-05-18` (commit `aacf0a73` → `790f9e28`)

Other zkVMs only have a single run in the monitor, so their data is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)