### PR TITLE
chore: add lambdavm to zkVM test monitor + prettify display names

### DIFF
--- a/.github/workflows/sync-test-monitor.yml
+++ b/.github/workflows/sync-test-monitor.yml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p src/data/test-monitor-raw
-          ZKVMS="zisk jolt sp1 r0vm openvm pico airbender"
+          ZKVMS="zisk jolt sp1 r0vm openvm pico airbender lambdavm"
           for zkvm in $ZKVMS; do
             for suite in act4-standard act4-full; do
               echo "Fetching ${zkvm} ${suite}..."

--- a/src/app/track/page.tsx
+++ b/src/app/track/page.tsx
@@ -25,6 +25,18 @@ function ComplianceStatus({ status }: { status?: string }) {
   }
 }
 
+// Display names for zkVMs — the test monitor keys them by lowercase identifier
+const zkvmDisplayNames: Record<string, string> = {
+  airbender: "Airbender",
+  jolt: "Jolt",
+  lambdavm: "LambdaVM",
+  openvm: "OpenVM",
+  pico: "Pico",
+  r0vm: "R0VM",
+  sp1: "SP1",
+  zisk: "ZisK",
+};
+
 const tabs = [
   { id: "zkvm", label: "zkVM Readiness" },
   { id: "clients", label: "Ethereum Clients" },
@@ -107,7 +119,7 @@ export default function TrackPage() {
                     .map(([name, zkvm]) => (
                     <tr key={name} className="border-b border-border hover:bg-muted/30 transition-colors">
                       <td className="py-4 px-4 text-center">
-                        <span className="font-semibold text-foreground uppercase">{name}</span>
+                        <span className="font-semibold text-foreground">{zkvmDisplayNames[name] ?? name.toUpperCase()}</span>
                       </td>
                       <td className="py-4 px-4 text-center">
                         <code className="text-sm text-muted-foreground">{zkvm.commit}</code>

--- a/src/data/test-monitor-summary.json
+++ b/src/data/test-monitor-summary.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-22T15:12:29.272Z",
+  "lastUpdated": "2026-05-22T17:22:18.194Z",
   "zkvms": {
     "airbender": {
       "isa": "RV32IM",
@@ -35,6 +35,24 @@
         "failed": 8,
         "total": 72,
         "passRate": "86.1"
+      }
+    },
+    "lambdavm": {
+      "isa": "RV64IM",
+      "commit": "6dbdc2ec",
+      "lastRun": "2026-05-22T00:48:53Z",
+      "isRV64": true,
+      "full": {
+        "passed": 64,
+        "failed": 0,
+        "total": 64,
+        "passRate": "100.0"
+      },
+      "standard": {
+        "passed": 61,
+        "failed": 8,
+        "total": 72,
+        "passRate": "84.7"
       }
     },
     "openvm": {


### PR DESCRIPTION
## Summary

lambdavm was added to [eth-act/zkevm-test-monitor](https://github.com/eth-act/zkevm-test-monitor). This PR wires it into the website and tidies up zkVM name rendering.

## Changes

**Add lambdavm**
- Add `lambdavm` to the nightly sync `ZKVMS` list in `sync-test-monitor.yml`
- Seed `test-monitor-summary.json` with its current run so it shows immediately rather than after the next nightly sync
- lambdavm reports `RV64IM`, so it appears in the RV64-filtered readiness table

**Prettify display names**
- The track page uppercased the monitor's lowercase identifier keys (`ZISK`, `LAMBDAVM`, …). Map them to nicely-cased display names — Jolt, LambdaVM, SP1, ZisK — with an uppercase fallback for unknown keys

## Notes

Independent of #48 (the test-monitor latest-run fix) — different source files. The only shared file is the generated `test-monitor-summary.json`, where this PR only inserts the `lambdavm` block and #48 only touches the sp1/zisk rows, so the two merge in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)