### PR TITLE
chore: remove SP1

### DIFF
--- a/.github/workflows/sync-test-monitor.yml
+++ b/.github/workflows/sync-test-monitor.yml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p src/data/test-monitor-raw
-          ZKVMS="zisk jolt sp1 r0vm openvm pico airbender"
+          ZKVMS="zisk jolt sp1 r0vm openvm pico airbender lambdavm"
           for zkvm in $ZKVMS; do
             for suite in act4-standard act4-full; do
               echo "Fetching ${zkvm} ${suite}..."

--- a/.github/workflows/sync-test-monitor.yml
+++ b/.github/workflows/sync-test-monitor.yml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           mkdir -p src/data/test-monitor-raw
-          ZKVMS="zisk jolt sp1 r0vm openvm pico airbender lambdavm"
+          ZKVMS="zisk jolt r0vm openvm pico airbender lambdavm"
           for zkvm in $ZKVMS; do
             for suite in act4-standard act4-full; do
               echo "Fetching ${zkvm} ${suite}..."

--- a/src/app/track/page.tsx
+++ b/src/app/track/page.tsx
@@ -33,7 +33,6 @@ const zkvmDisplayNames: Record<string, string> = {
   openvm: "OpenVM",
   pico: "Pico",
   r0vm: "R0VM",
-  sp1: "SP1",
   zisk: "ZisK",
 };
 

--- a/src/app/track/page.tsx
+++ b/src/app/track/page.tsx
@@ -25,6 +25,18 @@ function ComplianceStatus({ status }: { status?: string }) {
   }
 }
 
+// Display names for zkVMs — the test monitor keys them by lowercase identifier
+const zkvmDisplayNames: Record<string, string> = {
+  airbender: "Airbender",
+  jolt: "Jolt",
+  lambdavm: "LambdaVM",
+  openvm: "OpenVM",
+  pico: "Pico",
+  r0vm: "R0VM",
+  sp1: "SP1",
+  zisk: "ZisK",
+};
+
 const tabs = [
   { id: "zkvm", label: "zkVM Readiness" },
   { id: "clients", label: "Ethereum Clients" },
@@ -107,7 +119,7 @@ export default function TrackPage() {
                     .map(([name, zkvm]) => (
                     <tr key={name} className="border-b border-border hover:bg-muted/30 transition-colors">
                       <td className="py-4 px-4 text-center">
-                        <span className="font-semibold text-foreground uppercase">{name}</span>
+                        <span className="font-semibold text-foreground">{zkvmDisplayNames[name] ?? name.toUpperCase()}</span>
                       </td>
                       <td className="py-4 px-4 text-center">
                         <code className="text-sm text-muted-foreground">{zkvm.commit}</code>

--- a/src/data/test-monitor-summary.json
+++ b/src/data/test-monitor-summary.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-22T15:12:29.272Z",
+  "lastUpdated": "2026-05-22T17:22:18.194Z",
   "zkvms": {
     "airbender": {
       "isa": "RV32IM",
@@ -35,6 +35,24 @@
         "failed": 8,
         "total": 72,
         "passRate": "86.1"
+      }
+    },
+    "lambdavm": {
+      "isa": "RV64IM",
+      "commit": "6dbdc2ec",
+      "lastRun": "2026-05-22T00:48:53Z",
+      "isRV64": true,
+      "full": {
+        "passed": 64,
+        "failed": 0,
+        "total": 64,
+        "passRate": "100.0"
+      },
+      "standard": {
+        "passed": 61,
+        "failed": 8,
+        "total": 72,
+        "passRate": "84.7"
       }
     },
     "openvm": {

--- a/src/data/test-monitor-summary.json
+++ b/src/data/test-monitor-summary.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-05-22T17:22:18.194Z",
+  "lastUpdated": "2026-05-22T17:22:55.451Z",
   "zkvms": {
     "airbender": {
       "isa": "RV32IM",
@@ -107,24 +107,6 @@
         "failed": 72,
         "total": 72,
         "passRate": "0.0"
-      }
-    },
-    "sp1": {
-      "isa": "RV64IM",
-      "commit": "10995181",
-      "lastRun": "2026-04-15T20:52:07Z",
-      "isRV64": true,
-      "full": {
-        "passed": 62,
-        "failed": 2,
-        "total": 64,
-        "passRate": "96.9"
-      },
-      "standard": {
-        "passed": 62,
-        "failed": 10,
-        "total": 72,
-        "passRate": "86.1"
       }
     },
     "zisk": {


### PR DESCRIPTION
## Summary

SP1's multi-GPU prover is closed source, so SP1 does not satisfy the **Open Source** inclusion criterion. This removes it from the zkVM Readiness table.

## Changes

- Drop `sp1` from the nightly sync `ZKVMS` list in `sync-test-monitor.yml`
- Remove `sp1` from the display-name map
- Remove the `sp1` entry from `test-monitor-summary.json`

## Stacking

Branched off #49 (which is itself stacked on #50). Merge order: **#50 → #49 → this**. Once those land, this PR's diff collapses to just the SP1 removal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)