### PR TITLE
chore: add OpenVM to the zkVM readiness table

### DIFF
--- a/src/data/test-monitor-summary.json
+++ b/src/data/test-monitor-summary.json
@@ -1,5 +1,5 @@
 {
-  "lastUpdated": "2026-07-29T06:52:22.951Z",
+  "lastUpdated": "2026-07-29T17:06:45.184Z",
   "zkvms": {
     "airbender": {
       "isa": "RV32IM",
@@ -56,21 +56,21 @@
       }
     },
     "openvm": {
-      "isa": "RV32IM",
-      "commit": "bf11b4a5",
-      "lastRun": "2026-06-13T16:24:36Z",
-      "isRV64": false,
+      "isa": "RV64IM_Zicclsm",
+      "commit": "538c5488",
+      "lastRun": "2026-07-29T16:55:00Z",
+      "isRV64": true,
       "full": {
-        "passed": 47,
+        "passed": 72,
         "failed": 0,
-        "total": 47,
+        "total": 72,
         "passRate": "100.0"
       },
       "standard": {
-        "passed": 0,
-        "failed": 72,
+        "passed": 72,
+        "failed": 0,
         "total": 72,
-        "passRate": "0.0"
+        "passRate": "100.0"
       }
     },
     "zisk": {


### PR DESCRIPTION
## Summary

[eth-act/zkevm-test-monitor#34](https://github.com/eth-act/zkevm-test-monitor/pull/34) landed: OpenVM is pinned to [`v2.1.0-preview`](https://github.com/openvm-org/openvm/releases/tag/v2.1.0-preview) (`538c5488`) and its compliance coverage moved from RV32IM to the native `RV64IM_Zicclsm` target profile. That makes OpenVM eligible for the zkVM Readiness table, which filters on RV64.

## Changes

- Regenerate `src/data/test-monitor-summary.json` from the monitor's current history so OpenVM shows immediately rather than after the next nightly sync (same approach as #49)

The OpenVM row goes from `RV32IM` / `0/72` (excluded by the RV64 filter) to:

| zkVM | Commit | ISA Tests | Last Run |
| --- | --- | --- | --- |
| OpenVM | `538c5488` | 72/72 | 7/29/2026 |

No other zkVM rows change — the regeneration touched only the `openvm` block and `lastUpdated`.

## Verification

- Rebuilt the raw monitor data exactly as `sync-test-monitor.yml` does (same `ZKVMS` list, same `gh api` fetch), then ran `node scripts/transform-test-data.js` — so this is byte-identical to what the nightly sync would produce
- `npm run build` passes; the prerendered `/track` HTML lists Jolt, LambdaVM, OpenVM, ZisK, with OpenVM at 72/72 in the pass colour
- `npm run lint` is unchanged (the 5 pre-existing errors are in `scripts/*.js` and `src/app/media/page.tsx`)

## Notes

- No workflow change needed — `openvm` is already in the `ZKVMS` sync list, and `zkvmDisplayNames` already maps it to "OpenVM".
- The monitor now reports `has_proving: true` for OpenVM with zero prove/verify failures on all 72 tests. `scripts/transform-test-data.js` drops `has_proving` / `prove_failed` / `verify_failed`, so the site can't show that yet. Surfacing a proving/verification column would be a nice follow-up — LambdaVM, Jolt and ZisK also have proving data.
- `src/data/zkevm-tracker.ts` still carries a stale OpenVM entry (`rv32im`, 47/47) in `allZkvmData`, but `zkevmData`/`allZkvmData` are dead — `ZKEVMReadiness.tsx` and `ZKEVMTracker.tsx` are no longer imported anywhere and `/zkvm-tracker` redirects to `/track`. Left alone here rather than widening this PR; worth deleting separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
